### PR TITLE
Fix #31 Now reading configuration from file

### DIFF
--- a/basestation.py
+++ b/basestation.py
@@ -1122,8 +1122,7 @@ class SendThread(PublishThread):
             # update stats
             AppData().incrStats(STAT_NUM_SERVER_UNREACHABLE)
             # happens when could not contact server
-            #pass
-            raise
+            pass
         else:
             # server answered
             

--- a/basestation.py
+++ b/basestation.py
@@ -59,6 +59,8 @@ DEFAULT_LOGFILE                        = 'basestation.sol'
 DEFAULT_SERVER                         = 'localhost:8081'
 DEFAULT_SERVERTOKEN                    = 'DEFAULT_SERVERTOKEN'
 DEFAULT_BASESTATIONTOKEN               = 'DEFAULT_BASESTATIONTOKEN'
+DEFAULT_BASESTATIONPRIVKEY             = 'basestation.ppk'
+DEFAULT_BASESTATIONCERT                = 'basestation.cert'
 DEFAULT_SERVERCERT                     = 'server.cert'
 DEFAULT_SENDPERIODMINUTES              = 1
 DEFAULT_FILEPERIODMINUTES              = 1
@@ -1141,8 +1143,8 @@ class CherryPySSL(bottle.ServerAdapter):
         from cherrypy.wsgiserver.ssl_pyopenssl import pyOpenSSLAdapter
         server = wsgiserver.CherryPyWSGIServer((self.host, self.port), handler)
         server.ssl_adapter = pyOpenSSLAdapter(
-            certificate           = "basestation.cert",
-            private_key           = "basestation.ppk",
+            certificate           = DEFAULT_BASESTATIONCERT,
+            private_key           = DEFAULT_BASESTATIONPRIVKEY,
         )
         try:
             server.start()
@@ -1562,6 +1564,8 @@ if __name__ == '__main__':
             DEFAULT_SERIALPORT = cf_parser.get('basestation','serialport')
         if cf_parser.has_option('basestation','tcpport'):
             DEFAULT_TCPPORT = cf_parser.get('basestation','tcpport')
+        if cf_parser.has_option('basestation','token'):
+            DEFAULT_BASESTATIONTOKEN = cf_parser.get('basestation','token')
         if cf_parser.has_option('basestation','filecommitdelay'):
             DEFAULT_FILECOMMITDELAY_S = cf_parser.getint(
                     'basestation',
@@ -1574,14 +1578,18 @@ if __name__ == '__main__':
             DEFAULT_FILEPERIODMINUTES = cf_parser.getint(
                     'basestation',
                     'fileperiodminutes')
+        if cf_parser.has_option('basestation','crashlog'):
+            DEFAULT_BASESTATIONTOKEN = cf_parser.get('basestation','crashlog')
+        if cf_parser.has_option('basestation','backup'):
+            DEFAULT_BASESTATIONTOKEN = cf_parser.get('basestation','backup')
 
     if cf_parser.has_section('server'):
         if cf_parser.has_option('server','host'):
             DEFAULT_SERVER = cf_parser.get('server','host')
         if cf_parser.has_option('server','token'):
             DEFAULT_SERVERTOKEN = cf_parser.get('server','token')
-        if cf_parser.has_option('server','cert'):
-            DEFAULT_SERVERCERT = cf_parser.get('server','cert')
+        if cf_parser.has_option('server','certfile'):
+            DEFAULT_SERVERCERT = cf_parser.get('server','certfile')
 
     # parse the command line
     parser = OptionParser("usage: %prog [options]")

--- a/basestation.py
+++ b/basestation.py
@@ -18,6 +18,7 @@ import pickle
 import random
 import traceback
 from   optparse                             import OptionParser
+from   ConfigParser                         import SafeConfigParser
 
 import OpenCli
 import basestation_version
@@ -46,6 +47,7 @@ FLOW_DEFAULT                           = 'default'
 FLOW_ON                                = 'on'
 FLOW_OFF                               = 'off'
 
+DEFAULT_CONFIGFILE                     = 'basestation.config'
 DEFAULT_SERIALPORT                     = 'COM14'
 DEFAULT_TCPPORT                        = 8080
 DEFAULT_FILECOMMITDELAY_S              = 60
@@ -57,6 +59,7 @@ DEFAULT_LOGFILE                        = 'basestation.sol'
 DEFAULT_SERVER                         = 'localhost:8081'
 DEFAULT_SERVERTOKEN                    = 'DEFAULT_SERVERTOKEN'
 DEFAULT_BASESTATIONTOKEN               = 'DEFAULT_BASESTATIONTOKEN'
+DEFAULT_SERVERCERT                     = 'server.cert'
 DEFAULT_SENDPERIODMINUTES              = 1
 DEFAULT_FILEPERIODMINUTES              = 1
 
@@ -1113,13 +1116,14 @@ class SendThread(PublishThread):
                 'https://{0}/api/v1/o.json'.format(AppData().getConfig('server')),
                 headers = {'X-REALMS-Token': AppData().getConfig('servertoken')},
                 json    = payload,
-                verify  = 'server.cert',
+                verify  = DEFAULT_SERVERCERT,
             )
         except requests.exceptions.RequestException as err:
             # update stats
             AppData().incrStats(STAT_NUM_SERVER_UNREACHABLE)
             # happens when could not contact server
-            pass
+            #pass
+            raise
         else:
             # server answered
             
@@ -1550,7 +1554,36 @@ def main(serialport,tcpport):
     )
 
 if __name__ == '__main__':
-    
+    # parse the config file
+    cf_parser = SafeConfigParser()
+    cf_parser.read(DEFAULT_CONFIGFILE)
+
+    if cf_parser.has_section('basestation'):
+        if cf_parser.has_option('basestation','serialport'):
+            DEFAULT_SERIALPORT = cf_parser.get('basestation','serialport')
+        if cf_parser.has_option('basestation','tcpport'):
+            DEFAULT_TCPPORT = cf_parser.get('basestation','tcpport')
+        if cf_parser.has_option('basestation','filecommitdelay'):
+            DEFAULT_FILECOMMITDELAY_S = cf_parser.getint(
+                    'basestation',
+                    'filecommitdelay')
+        if cf_parser.has_option('basestation','sendperiodminutes'):
+            DEFAULT_SENDPERIODMINUTES = cf_parser.getint(
+                    'basestation',
+                    'sendperiodminutes')
+        if cf_parser.has_option('basestation','fileperiodminutes'):
+            DEFAULT_FILEPERIODMINUTES = cf_parser.getint(
+                    'basestation',
+                    'fileperiodminutes')
+
+    if cf_parser.has_section('server'):
+        if cf_parser.has_option('server','host'):
+            DEFAULT_SERVER = cf_parser.get('server','host')
+        if cf_parser.has_option('server','token'):
+            DEFAULT_SERVERTOKEN = cf_parser.get('server','token')
+        if cf_parser.has_option('server','cert'):
+            DEFAULT_SERVERCERT = cf_parser.get('server','cert')
+
     # parse the command line
     parser = OptionParser("usage: %prog [options]")
     parser.add_option(


### PR DESCRIPTION
Configuration file documentation will be added soon.

Here is an example:
```
[basestation]
# Connection
serialport = /dev/ttyUSB3
tcpport = 8080

# Application
filecommitdelay = 60
sendperiodminutes = 1 
fileperiodminutes = 1 

# Security
token = DEFAULT_BASESTATIONTOKEN

# Files
crashlogfile = basestation.crashlog
backupfile = basestation.backup

[server]
# Connection
host = realms:8081

# Security
token = DEFAULT_SERVERTOKEN
certfile = server.cert
```